### PR TITLE
nRF52832-MDK pin mappings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,6 @@ before_script:
 script:
   - make REV=1
   - make clean REV=1
-  - make REV=2 
+  - make REV=2
+  - make clean REV=1
+  - make REV=MDK

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,8 +15,7 @@
         {
             "label": "clean",
             "type": "shell",
-            "command": "make clean REV=1
-            ",
+            "command": "make clean REV=1",
             "problemMatcher": []
         }
     ],
@@ -25,7 +24,8 @@
             "id": "rev",
             "description": "Revision:",
             "default": "2",
-            "type": "promptString"
+            "type": "pickString",
+            "options": ["1", "2", "MDK"]
         },
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,8 @@ ifeq ($(REV), 1)
   CFLAGS += -DPCB_REV_1
 else ifeq ($(REV), 2)
   CFLAGS += -DPCB_REV_2
+else ifeq ($(REV), MDK)
+  CFLAGS += -DBOARD_MDK
 else
   $(error Invalid board revision)
 endif

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ $(foreach target, $(TARGETS), $(call define_target, $(target)))
 
 pyocdflash:
 	@echo Flashing: $(OUTPUT_DIRECTORY)/nrf52832_xxaa.hex
-	pyocd -t nrf52 -se _build/nrf52832_xxaa.hex
+	pyocd flash -t NRF52 -e chip _build/nrf52832_xxaa.hex
 
 # Flash the program using nRF Command Line Tools
 flash: default

--- a/README.MD
+++ b/README.MD
@@ -179,16 +179,27 @@ The CLI is accessible through UART and the JLink RTT, setup is described below:
 
 The following MCU pins correspond with UART RX and TX pins:
 
-|    | PIN# |
-|---:|:----:|
-| RX |  23  |
-| TX |  24  |
+|    | REV 1/2 | MDK |
+|---:|:-------:|:---:|
+| RX |    23   |  17 |
+| TX |    24   |  18 |
 
 Keep in mind that when using an RS232/UART dongle, you need to hook up the dongle's `TX` pin with the MCU's `RX` pin and the dongle's `RX` pin with the MCU's `TX` pin:
 
 `RS232 TX` -> `Device RX`
 
 `RS232 RX` -> `Device TX`
+
+Your terminal emulator should then have the following settings for a serial terminal:
+
+|                    Setting | Valud     |
+|---------------------------:|:----------|
+|                       Baud | 921600    |
+|                       Data | 8-bit     |
+|                     Patiry | None      |
+|                  Stop bits | 1-bit     |
+|               Flow Control | None      |
+| Newline (receive+transmit) | LF (or \n)| 
 
 ### JLink RTT
 

--- a/board_config/custom_board.h
+++ b/board_config/custom_board.h
@@ -48,6 +48,8 @@ extern "C" {
 #include "pin_mappings_rev_2.h"
 #elif defined PCB_REV_1
 #include "pin_mappings_rev_1.h"
+#elif defined BOARD_MDK
+#include "pin_mappings_mdk.h"
 #else
 #error "Board is not defined"
 #endif

--- a/board_config/pin_mappings_mdk.h
+++ b/board_config/pin_mappings_mdk.h
@@ -1,0 +1,52 @@
+/**
+ * @file pin_mappings_mdk.h
+ * @author UBC Capstone Team 2020/2021
+ * @brief Pin definitions for nRF52832-MDK devboard 
+ */
+
+#ifndef PIN_MAP_MDK_H
+#define PIN_MAP_MDK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*******************************
+ * @brief UART pin mappings
+ *******************************/
+
+#define RX_PIN_NUMBER  17
+#define TX_PIN_NUMBER  18
+
+/*******************************
+ * @brief SPI pin mappings
+ *******************************/
+
+/* ICM206649 SPI pin mappings */
+#define SPI0_PERIPH           0
+#define SPI0_ICM20649_CS_PIN  3
+#define SPI0_MISO_PIN         9
+#define SPI0_MOSI_PIN         10
+#define SPI0_CLK_PIN          11
+
+/* ADXL372 and MT25QL256 shared SPI bus pin mappings */
+#define SPI2_PERIPH              2
+#define SPI2_ADXL372_CS_PIN      8
+#define SPI2_MT25Q_CS_PIN        15
+#define SPI2_MOSI_PIN            12
+#define SPI2_MISO_PIN            16
+#define SPI2_CLK_PIN             13
+
+/*******************************
+ * @brief I2C pin mappings
+ *******************************/
+
+#define I2C1_PERIPH               1 /*!< I2C1 used */
+#define I2C1_SDA                 20
+#define I2C1_SCL                 19
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PIN_MAP_MDK_H */


### PR DESCRIPTION
Pin mappings specific to nRF52832-MDK devboard

The devboard doesn't have access to pins 23 and 24 that Rev1 and Rev2 use.